### PR TITLE
Add ServiceInstance#credentials

### DIFF
--- a/lib/cfoundry/v2/service_instance.rb
+++ b/lib/cfoundry/v2/service_instance.rb
@@ -4,6 +4,7 @@ module CFoundry::V2
   class ServiceInstance < Model
     attribute :name, :string
     attribute :dashboard_url, :string
+    attribute :credentials, :hash
     to_one    :space
     to_one    :service_plan
     to_many   :service_bindings


### PR DESCRIPTION
We need to expose the "credentials" field on the ServiceInstance model to allow us to retrieve AppDirect IDs
