### PR TITLE
Fix register user

### DIFF
--- a/lib/cfoundry/v2/client.rb
+++ b/lib/cfoundry/v2/client.rb
@@ -53,7 +53,7 @@ module CFoundry::V2
     def register(email, password)
       uaa_user = @base.uaa.add_user(email, password)
       cc_user = user
-      cc_user.guid = uaa_user['id']
+      cc_user.guid = uaa_user[:id]
       cc_user.create!
       cc_user
     end

--- a/spec/cfoundry/v2/client_spec.rb
+++ b/spec/cfoundry/v2/client_spec.rb
@@ -14,7 +14,7 @@ module CFoundry
 
         it "creates the user in uaa and ccng" do
           client.base.stub(:uaa) { uaa }
-          uaa.stub(:add_user).with(email, password) { {"id" => "1234"} }
+          uaa.stub(:add_user).with(email, password) { {:id => "1234"} }
 
           user = build(:user)
           client.stub(:user) { user }


### PR DESCRIPTION
Fixes an error when registering a new user:

```
CFoundry::MessageParseError: 1001: Request invalid due to parse error: Field: guid, Error: Missing field guid
```

UAA Scim objects uses symbolized keys since commit b1d8e8f741
