### PR TITLE
Add attributes required by service brokers to Service and ServicePlan

### DIFF
--- a/lib/cfoundry/v2/service.rb
+++ b/lib/cfoundry/v2/service.rb
@@ -4,6 +4,7 @@ module CFoundry::V2
   class Service < Model
     attribute :label, String
     attribute :provider, String
+    attribute :unique_id, String
     attribute :url, :url
     attribute :description, String
     attribute :version, String
@@ -13,6 +14,7 @@ module CFoundry::V2
     attribute :timeout, Integer, :default => nil
     attribute :active, :boolean, :default => false
     attribute :extra, String
+    attribute :tags, [String]
     to_many   :service_plans
 
     queryable_by :service_plan_guid

--- a/lib/cfoundry/v2/service_plan.rb
+++ b/lib/cfoundry/v2/service_plan.rb
@@ -4,6 +4,8 @@ module CFoundry::V2
   class ServicePlan < Model
     attribute :name, :string
     attribute :description, :string
+    attribute :unique_id, String
+    attribute :free, :boolean, :default => false
     attribute :extra, :string
     to_one    :service
     to_many   :service_instances

--- a/spec/cfoundry/v2/service_plan_spec.rb
+++ b/spec/cfoundry/v2/service_plan_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+module CFoundry
+  module V2
+    describe ServicePlan do
+      let(:client) { build(:client) }
+
+      subject do
+        build(:service_plan)
+      end
+
+      before :each do
+stub_request(:get, /\/service_plans\/service-plan-guid-\d{1,2}/).to_return :status => 200,
+          :headers => {'Content-Type' => 'application/json'},
+          :body => <<EOF
+  {
+    "metadata": {
+      "guid": "d1251ac1-fe42-4b4a-84d4-e31e95b547d8",
+      "url": "/v2/service_plans/d1251ac1-fe42-4b4a-84d4-e31e95b547d8",
+      "created_at": "2013-08-28T12:28:35+04:00",
+      "updated_at": "2013-08-28T12:33:27+04:00"
+    },
+    "entity": {
+      "name": "free",
+      "free": true,
+      "description": "free as in beer",
+      "unique_id": "0aa2f82c-6918-41df-b676-c275b5954ed7",
+      "extra": ""
+    }
+  }
+EOF
+      end
+
+      let(:uuid) { "4692e0ca-25ed-495e-9ae1-fcb0bcf26a96" }
+
+      it "has unique_id that can be mutated" do
+        subject.unique_id.should == "0aa2f82c-6918-41df-b676-c275b5954ed7"
+
+        subject.unique_id = uuid
+        subject.unique_id.should eq(uuid)
+      end
+
+      it "has free/paid indicator attribute" do
+        subject.free.should be_true
+      end
+    end
+  end
+end

--- a/spec/cfoundry/v2/service_spec.rb
+++ b/spec/cfoundry/v2/service_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+module CFoundry
+  module V2
+    describe Service do
+      let(:client) { build(:client) }
+
+      subject do
+        build(:service)
+      end
+
+      before :each do
+stub_request(:get, /\/services\/service-guid-\d{1,2}/).to_return :status => 200,
+          :headers => {'Content-Type' => 'application/json'},
+          :body => <<EOF
+  {
+    "metadata": {
+      "guid": "d1251ac1-fe42-4b4a-84d4-e31e95b547d8",
+      "url": "/v2/services/d1251ac1-fe42-4b4a-84d4-e31e95b547d8",
+      "created_at": "2013-08-28T12:28:35+04:00",
+      "updated_at": "2013-08-28T12:33:27+04:00"
+    },
+    "entity": {
+      "label": "rabbitmq",
+      "provider": "rabbitherd",
+      "url": "http://rabbitmq.com",
+      "description": "RabbitMQ service",
+      "version": "1.0",
+      "info_url": null,
+      "active": true,
+      "bindable": true,
+      "unique_id": "0aa2f82c-6918-41df-b676-c275b5954ed7",
+      "extra": "",
+      "tags": [
+
+      ],
+      "documentation_url": null,
+      "service_plans_url": "/v2/services/d1251ac1-fe42-4b4a-84d4-e31e95b547d8/service_plans"
+    }
+  }
+EOF
+      end
+
+      let(:uuid) { "4692e0ca-25ed-495e-9ae1-fcb0bcf26a96" }
+
+      it "has unique_id that can be mutated" do
+        subject.unique_id.should == "0aa2f82c-6918-41df-b676-c275b5954ed7"
+
+        subject.unique_id = uuid
+        subject.unique_id.should eq(uuid)
+      end
+
+      it "has tags" do
+        subject.tags.should == []
+      end
+    end
+  end
+end

--- a/spec/factories/services_factory.rb
+++ b/spec/factories/services_factory.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :service, :class => CFoundry::V2::Service do
+    sequence(:guid) { |n| "service-guid-#{n}" }
+    ignore do
+      client { FactoryGirl.build(:client) }
+    end
+
+    initialize_with { new(guid, client) }
+  end
+end


### PR DESCRIPTION
These updates make it possible to use cfoundry models for service broker development. Fixes #17.
