### PR TITLE
Fix regression when uploading app bits

### DIFF
--- a/lib/cfoundry/baseclient.rb
+++ b/lib/cfoundry/baseclient.rb
@@ -204,7 +204,7 @@ module CFoundry
     end
 
     def parse_json(x)
-      if x.empty?
+      if x.nil? || x.empty?
         raise MultiJson::DecodeError.new("Empty JSON string", [], "")
       else
         MultiJson.load(x, :symbolize_keys => true)

--- a/lib/cfoundry/v2/base.rb
+++ b/lib/cfoundry/v2/base.rb
@@ -33,7 +33,7 @@ module CFoundry::V2
         :params => {"async" => "true"},
         :accept => :json)
 
-      poll_upload_until_finished(response[:metadata][:guid])
+      poll_upload_until_finished(response[:metadata][:guid]) if response
     rescue EOFError
       retry
     end


### PR DESCRIPTION
Old cloud controllers doesn't support uploading app bits asynchronously, so they return an empty response (instead of the job guid). In that case, don't pool until the upload has finished (old behaviour).
