### PR TITLE
Allow push of any type of archive

### DIFF
--- a/lib/cfoundry/upload_helpers.rb
+++ b/lib/cfoundry/upload_helpers.rb
@@ -54,10 +54,8 @@ module CFoundry
     private
 
     def prepare_package(path, to)
-      if path =~ /\.(jar|war|zip)$/
-        CFoundry::Zip.unpack(path, to)
-      elsif (war_file = Dir.glob("#{path}/*.war").first)
-        CFoundry::Zip.unpack(war_file, to)
+      if (archive = find_archives_in_path(path).first)
+        CFoundry::Zip.unpack(archive, to)
       else
         FileUtils.mkdir(to)
 
@@ -76,6 +74,23 @@ module CFoundry
           File.delete s
         end
       end
+    end
+
+    def find_archives_in_path(path)
+      files = Array.new
+      list = Array.new
+      if path.include?('.')
+        files << path
+      else
+      files = Dir.glob(File.join(path, '*'))
+      end
+      files.each do |file|
+        File.open(file, 'r') do |fil|
+          prefix = fil.read(2)
+          list << file if prefix == 'PK'
+        end
+      end
+      list
     end
 
     def check_unreachable_links(files, path)

--- a/lib/cfoundry/upload_helpers.rb
+++ b/lib/cfoundry/upload_helpers.rb
@@ -79,10 +79,10 @@ module CFoundry
     def find_archives_in_path(path)
       files = Array.new
       list = Array.new
-      if path.include?('.')
+      if File.file?(path)
         files << path
       else
-      files = Dir.glob(File.join(path, '*'))
+        files = Dir.glob(File.join(path, '*'))
       end
       files.each do |file|
         File.open(file, 'r') do |fil|

--- a/lib/cfoundry/upload_helpers.rb
+++ b/lib/cfoundry/upload_helpers.rb
@@ -55,7 +55,7 @@ module CFoundry
 
     def prepare_package(path, to)
       archive = find_archives_in_path(path)
-      if (archive != [] && archive != nil)
+      if (archive.length == 1)
         CFoundry::Zip.unpack(archive.first, to)
       else
         FileUtils.mkdir(to)
@@ -85,7 +85,7 @@ module CFoundry
       else
         files = Dir.glob(File.join(path, '*'))
       end
-      # puts "files found #{files}"
+
       files.each do |file|
         if File.file?(file)
           File.open(file, 'r') do |fil|

--- a/lib/cfoundry/upload_helpers.rb
+++ b/lib/cfoundry/upload_helpers.rb
@@ -54,8 +54,9 @@ module CFoundry
     private
 
     def prepare_package(path, to)
-      if (archive = find_archives_in_path(path).first)
-        CFoundry::Zip.unpack(archive, to)
+      archive = find_archives_in_path(path)
+      if (archive != [] && archive != nil)
+        CFoundry::Zip.unpack(archive.first, to)
       else
         FileUtils.mkdir(to)
 
@@ -84,10 +85,13 @@ module CFoundry
       else
         files = Dir.glob(File.join(path, '*'))
       end
+      # puts "files found #{files}"
       files.each do |file|
-        File.open(file, 'r') do |fil|
-          prefix = fil.read(2)
-          list << file if prefix == 'PK'
+        if File.file?(file)
+          File.open(file, 'r') do |fil|
+            prefix = fil.read(2)
+            list << file if prefix == 'PK'
+          end
         end
       end
       list


### PR DESCRIPTION
I added some code to allow any type of archive to be pushed rather than just .zip/.war/.jar. To do this I check if the magic number "PK" is contained. 
If multiple apps are located in the path defined only the first found will be pushed.

Regarding the CLA agreement as an IBM employee I shouldn't need to sign it though. If necessary I can refer you to the person responsible for these things.

Also for the testing I believe the RSpec available already covers the bit I added. 
