### PR TITLE
Fix token issuer logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 4.7.2
+
+Bug fix: --trace mode will now cause UAA interactions to log to STDERR instead of STDOUT. [@jimmida and @moonmaster9000]

--- a/cfoundry.gemspec
+++ b/cfoundry.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_dependency "activemodel", "<5.0.0", ">= 3.2.13"
-  s.add_dependency "cf-uaa-lib", "~> 2.0.0"
+  s.add_dependency "cf-uaa-lib", "~> 2.0.1"
   s.add_dependency "multi_json", "~> 1.7"
   s.add_dependency "multipart-post", "~> 1.1"
   s.add_dependency "rubyzip", "~> 0.9"

--- a/lib/cfoundry/uaaclient.rb
+++ b/lib/cfoundry/uaaclient.rb
@@ -107,7 +107,14 @@ module CFoundry
         :http_proxy => @http_proxy,
         :https_proxy => @https_proxy
       )
-      @token_issuer.logger.level = @trace ? Logger::Severity::TRACE : 1
+
+      if @trace
+        @token_issuer.logger = CF::UAA::Util.default_logger(:trace, STDERR)
+        CF::UAA::Util.default_logger(nil, STDOUT)
+      else
+        @token_issuer.logger.level = Logger::INFO
+      end
+
       @token_issuer
     end
 

--- a/lib/cfoundry/version.rb
+++ b/lib/cfoundry/version.rb
@@ -1,4 +1,4 @@
 module CFoundry # :nodoc:
   # CFoundry library version number.
-  VERSION = "4.7.1".freeze
+  VERSION = "4.7.2".freeze
 end

--- a/spec/cfoundry/uaaclient_spec.rb
+++ b/spec/cfoundry/uaaclient_spec.rb
@@ -375,6 +375,16 @@ EOF
       expect(uaa.send(:token_issuer).logger.level).to eq -1
     end
 
+    it "sets the log device to STDERR if #trace is true" do
+      uaa.trace = true
+      expect(uaa.send(:token_issuer).logger.send(:instance_variable_get, :@logdev).dev).to eq STDERR
+    end
+
+    it "sets the log device to STDOUT if #trace is false" do
+      uaa.trace = false
+      expect(uaa.send(:token_issuer).logger.send(:instance_variable_get, :@logdev).dev).to eq STDOUT
+    end
+
     it "has logging level 1 if #trace is false" do
       uaa.trace = false
       expect(uaa.send(:token_issuer).logger.level).to eq 1


### PR DESCRIPTION
Token issuer was logging to STDOUT in trace mode, instead of STDERR. All other trace logging was sending to STDERR, it made no sense to have token issuer log to STDOUT. 
